### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,7 @@ repos:
   rev: v0.39.0
   hooks:
   - id: markdownlint
+- repo: https://github.com/renovatebot/pre-commit-hooks
+  rev: 37.353.0
+  hooks:
+    - id: renovate-config-validator

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -15,6 +15,7 @@ gidNumber: 5501
 ```
 
 > ⚠️ **NOTE**
+>
 > - `ou` and `gidNumber` **MUST** be provided.
 > - `ou` **MUST** be unique.
 
@@ -28,6 +29,7 @@ gidNumber: 5502
 ```
 
 > ⚠️ **NOTE**
+>
 > - This assumes that the Group `superheros` already exists.
 
 ## Modify a Group
@@ -76,6 +78,7 @@ userPassword: {SHA256}6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e
 ```
 
 > ⚠️ **NOTE**
+>
 > - `cn`, `uidNumber`, and `gidNumber` **MUST** be provided.
 > - `cn` **MUST** be unique.
 > - `userPassword` **ONLY** supports SHA-256 (prefixed with `{SHA256}`) and
@@ -94,6 +97,7 @@ delete: mail
 ```
 
 > ⚠️ **NOTE**
+>
 > - Custom attributes are also supported.
 
 ## Rename a User
@@ -137,6 +141,7 @@ memberUid: 5002
 ```
 
 > ⚠️ **NOTE**
+>
 > - The group should **NOT** be the user's primary group.
 
 ## Remove Users from additional Group
@@ -150,4 +155,5 @@ memberUid: 5002
 ```
 
 > ⚠️ **NOTE**
+>
 > - The group should **NOT** be the user's primary group.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard",
+    ":automergeDigest",
+    ":automergePatch",
+    ":automergeMinor",
+    ":rebaseStalePrs",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    "helpers:pinGitHubActionDigests",
+    "enablePreCommit"
+  ],
+  "automergeType": "pr",
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "groupName": "github actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "schedule": ["at any time"],
+      "additionalBranchPrefix": "auto-"
+    },
+    {
+      "groupName": "operator pip deps",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "schedule": ["at any time"],
+      "prPriority": 5,
+      "additionalBranchPrefix": "auto-"
+    },
+    {
+      "groupName": "operator pip deps",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["major"],
+      "schedule": ["at any time"],
+      "prPriority": 5
+    },
+    {
+      "groupName": "testing pip deps",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "schedule": ["at any time"],
+      "prPriority": 4,
+      "additionalBranchPrefix": "auto-"
+    },
+    {
+      "groupName": "testing deps",
+      "matchFiles": ["tox.ini"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "schedule": ["on monday"],
+      "additionalBranchPrefix": "auto-"
+    },
+    {
+      "groupName": "renovate packages",
+      "matchSourceUrlPrefixes": ["https://github.com/renovatebot/"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "schedule": ["at any time"],
+      "additionalBranchPrefix": "auto-"
+    },
+    {
+      "groupName": "pre-commit hooks",
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "schedule": ["at any time"],
+      "additionalBranchPrefix": "auto-"
+    }
+  ]
+}

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ deps =
     types-PyYAML
 commands =
     pre-commit install
-    pre-commit autoupdate
 
 [testenv:fmt]
 description = Apply coding style standards to code


### PR DESCRIPTION
The pull request tries to:

- Add Renovate configuration
- Update markdown files to follow the lint rules
- Use Renovate to update the pre-commit-hooks