### PR TITLE
chore: switch to platforms in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -27,9 +27,8 @@ actions:
         type: string
     required: ["path"]
 
-base: ubuntu@22.04
 platforms:
-  amd64:
+  ubuntu@22.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
This PR changes the charm's charmcraft `base` to `platforms`. This is a prerequisite to add main branch to charmcraftcache builds and switch to reusable workflows.