### PR TITLE
fix: ci permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,10 @@ on:
         required: true  
         type: boolean
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   publish:
     name: Publish Charm


### PR DESCRIPTION
add permissions to publish workflow